### PR TITLE
Render memory plots

### DIFF
--- a/source/run-statistics.rst
+++ b/source/run-statistics.rst
@@ -1,6 +1,8 @@
 Run Statistics
 ==============
 
-.. contents::
+.. contents:: List of Summary Statistics
+    :backlinks: top
+    :local:
 
 <<<MATCH_PATTERN_FOR_RUN_STATS_PLOTS>>>

--- a/source/run-statistics.rst
+++ b/source/run-statistics.rst
@@ -1,4 +1,6 @@
 Run Statistics
 ==============
 
+.. contents::
+
 <<<MATCH_PATTERN_FOR_RUN_STATS_PLOTS>>>

--- a/website_builder/builder.py
+++ b/website_builder/builder.py
@@ -177,7 +177,7 @@ class Builder:
             )
 
         print(f"Will build website into {self.build_dir} with;")
-        print(f"\tSource branch: {self.source_branch}.")
+        print(f"\tSource branch: {self.source_branch}")
         print(f"\tClean build  : {self.clean_build}")
         print(f"\tPlaintext fmt: {self.website_plaintext_format}")
 
@@ -355,9 +355,9 @@ class Builder:
         # Can probably do this with .apply() - revisit
         for index, row in self.df.iterrows():
             stats_file = row["stats_file"]
-            self.df.loc[
-                index, STATS.values("dataframe_col_name")
-            ] = STATS.read_from_file(file=stats_file, branch=self.source_branch)
+            self.df.loc[index, STATS.values("dataframe_col_name")] = (
+                STATS.read_from_file(file=stats_file, branch=self.source_branch)
+            )
 
         # Set the commit field from the sha field
         self.df["Commit"] = self.df["sha"].apply(

--- a/website_builder/builder.py
+++ b/website_builder/builder.py
@@ -288,17 +288,19 @@ class Builder:
 
         return
 
-    def format_as_title(self, text: str) -> str:
+    def format_as_title(self, text: str, char_if_rst: str = "-") -> str:
         """
         Format the text string provided into a plaintext title,
         in the format corresponding to self.website_plaintext_format.
 
         :param text: String to format into a title.
         :type text: str
+        :param char_if_rst: The character to place underneath the title if formatting an .rst file.
+        :type char_if_rst: str
         """
         title_writer: Callable[[str], str]
         if self.website_plaintext_format == "rst":
-            title_writer = lambda t: rst_title_format(t, "-")
+            title_writer = lambda t: rst_title_format(t, char_if_rst)
         elif format == "md":
             title_writer = md_title_format
         return title_writer(text)

--- a/website_builder/profiling_statistics.py
+++ b/website_builder/profiling_statistics.py
@@ -190,12 +190,16 @@ STATS = StatisticCollection(
     ),
     Statistic("duration", dtype=float, dataframe_col_name="Session duration (s)"),
     Statistic(
-        "cpu_time", plot_title="CPU Time", dtype=float, dataframe_col_name="CPU time"
+        "cpu_time",
+        plot_title="CPU Time",
+        dtype=float,
+        dataframe_col_name="CPU time",
+        plot_y_label="CPU time (s)",
     ),
     Statistic("pop_df_rows", plot_title="# rows in population dataframe", dtype=int),
     Statistic("pop_df_cols", plot_title="# cols in population dataframe", dtype=int),
     Statistic(
-        "pop_df_mem_mb",
+        "pop_df_mem_MB",
         plot_title="Memory used by population dataframe",
         dtype=float,
         plot_y_label="Dataframe size (MB)",
@@ -208,8 +212,18 @@ STATS = StatisticCollection(
     ),
     Statistic("disk_reads", dtype=int, dataframe_col_name="Disk reads"),
     Statistic("disk_writes", dtype=int, dataframe_col_name="Disk writes"),
-    Statistic("disk_read_MB", dtype=float, dataframe_col_name="Disk read (MB)"),
-    Statistic("disk_write_MB", dtype=float, dataframe_col_name="Disk write (MB)"),
+    Statistic(
+        "disk_read_MB",
+        plot_title="Disk read (MB)",
+        dtype=float,
+        dataframe_col_name="Disk read (MB)",
+    ),
+    Statistic(
+        "disk_write_MB",
+        plot_title="Disk write (MB)",
+        dtype=float,
+        dataframe_col_name="Disk write (MB)",
+    ),
     Statistic("disk_read_s", dtype=float, plot_title="Disk read time (s)"),
     Statistic("disk_write_s", dtype=float, plot_title="Disk write time (s)"),
 )


### PR DESCRIPTION
For https://github.com/UCL/TLOmodel/issues/1355 |

Edits the "run statistics" page to display the captured memory statistics, which the profiling runs were previously capturing but not displaying.

Making this it's own PR as the "run statistics" page is starting to get a bit bloated - it has no internal navigation but scrolling through the plots is quite a chore.

- Could add a collapse option for each individual plot
- Could try adding a "contents" at the top to allow for quick navigation

Opinions on this welcome :smile: 

#### Stats we're now plotting

The following (plottable) statistics are being captured by the profiling run; and those with a checked box are currently being plotted (includes those added by this PR):

- [ ] "duration": 26804.275735139847, (Duration of the entire profiling run)
- [x] "cpu_time": 26801.766409699998,
- [ ] "disk_reads": 1465,
- [ ] "disk_writes": 63014,
- [x] "disk_read_MB": 79.811584,
- [x] "disk_write_MB": 832.028672,
- [x] "disk_read_s": 0.505,
- [x] "disk_write_s": 33.234,
- [x] "pop_df_rows": 62000,
- [x] "pop_df_cols": 444,
- [x] "pop_df_mem_MB": 115.898045, (Pop. dataframe size in memory)
- [x] "pop_df_times_extended": 12,